### PR TITLE
add-travis-slack-integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,39 @@
 language: android 
+jdk: openjdk7
+sudo: false
+
+# Specify OS environment
+os:
+    - linux
+
+# blacklist
+branches:
+    except:
+        - /^legacy-.*$/
+        - /^poc-.*$/
+
 android:
   components:
+
+    # Latest revision of Android SDK Tools
     - platform-tools
+    - tools
+
+    # BuildTools version
     - build-tools-23.0.1
+
+    # SDK version
     - android-23
+
+    # Additional components
     - extra-android-m2repository
     - extra-google-m2repository
 
+
+# Setup notifications
+notifications:
+    slack: cscd-488:2uwpZGdpikeZyr31e9uozhhK#github
+
+# Execute Build
 script:
   - ./gradlew clean build


### PR DESCRIPTION
# Summary
1. Allow Travis CI to update #github channel on Slack
2. Cleanup travis configuration file and add blacklist functionality for specific branches
### Details

Allowed notification to #github channel
Added branch blacklisting
Configured to use latest platform tools
Set JDK version to openjdk7.  Openjdk8 does not seem to be supported
